### PR TITLE
Fix textdomain loading and remove hashtags

### DIFF
--- a/Classes/Plugin.php
+++ b/Classes/Plugin.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace ###AUTHOR_NAMESPACE###\###PLUGIN_KEY_PASCAL_CASE###;
+namespace AUTHOR_NAMESPACE\PLUGIN_KEY_PASCAL_CASE;
 
 class Plugin
 {
@@ -14,7 +14,7 @@ class Plugin
 
     public function __construct()
     {
-        add_action('plugins_loaded', array($this, 'loadTextDomain'));
+        add_action('plugins_loaded', array($this, 'loadPluginTextdomain'));
     }
 
     /**
@@ -22,7 +22,7 @@ class Plugin
      */
     public function loadPluginTextdomain()
     {
-        load_plugin_textdomain('TEXT-DOMAIN', false, dirname(plugin_basename(__FILE__)).'/languages');
+        load_plugin_textdomain('TEXT-DOMAIN', false, dirname(dirname(plugin_basename(__FILE__))).'/languages');
     }
 }
 

--- a/wp-plugin-default.php
+++ b/wp-plugin-default.php
@@ -1,17 +1,17 @@
 <?php
 /*
-Plugin Name: ###PLUGIN_NAME###
-Plugin URI: ###PLUGIN_URI###
-Description: ###PLUGIN_DESCRIPTION###
-Author: ###PLUGIN_AUTHOR###
+Plugin Name: PLUGIN_NAME
+Plugin URI: PLUGIN_URI
+Description: PLUGIN_DESCRIPTION
+Author: PLUGIN_AUTHOR
 Version: 0.0.1
-Author URI: ###AUTHOR_URI###
-Text Domain: ###TEXT_DOMAIN###
+Author URI: AUTHOR_URI
+Text Domain: TEXT_DOMAIN
 Domain Path: /languages
 */
 
 if (version_compare($wp_version, '4.6', '<') || version_compare(PHP_VERSION, '5.3', '<')) {
-    function ###PLUGIN_PREFIX###_compatability_warning()
+    function PLUGIN_PREFIX_compatability_warning()
     {
         echo '<div class="error"><p>'.sprintf(
             __('“%1$s” requires PHP %2$s (or newer) and WordPress %3$s (or newer) to function properly. Your site is using PHP %4$s and WordPress %5$s. Please upgrade. The plugin has been automatically deactivated.', 'TEXT-DOMAIN'),
@@ -25,13 +25,13 @@ if (version_compare($wp_version, '4.6', '<') || version_compare(PHP_VERSION, '5.
             unset($_GET['activate']);
         }
     }
-    add_action('admin_notices', '###PLUGIN_PREFIX###_compatability_warning');
+    add_action('admin_notices', 'PLUGIN_PREFIX_compatability_warning');
 
-    function ###PLUGIN_PREFIX###_deactivate_self()
+    function PLUGIN_PREFIX_deactivate_self()
     {
         deactivate_plugins(plugin_basename(__FILE__));
     }
-    add_action('admin_init', '###PLUGIN_PREFIX###_deactivate_self');
+    add_action('admin_init', 'PLUGIN_PREFIX_deactivate_self');
 
     return;
 } else {


### PR DESCRIPTION
I wanted to convert to WP Coding standards and found that the loading of the textdomain was not quite right. Please correct me if I am wrong, I have not tested it with actual translation files. Plus in order to run the plugin I had to remove the hashtags from the placeholders.