### PR TITLE
Change visibility of instance to private

### DIFF
--- a/Classes/Plugin.php
+++ b/Classes/Plugin.php
@@ -4,7 +4,7 @@ namespace AUTHOR_NAMESPACE\PLUGIN_NAMESPACE;
 
 class Plugin
 {
-    public static $instance;
+    private static $instance;
     public static $name = '';
     public static $prefix = '';
     public static $version = '';


### PR DESCRIPTION
Making the instance variable private makes sure that each access to the plugin object has to go through the provided accessor method. This completely hides the implementation of the singleton pattern from outside the class.